### PR TITLE
Multi graphql server config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,3 +1,6 @@
 Lint/DuplicateMethods:
   Exclude:
     - lib/graphql_connector.rb
+Metrics/BlockLength:
+  Exclude:
+    - spec/graphql_connector/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+## 1.0.0 (2020-1-26)
+
+### Breaking
+* add multiple graphql server querying
+* `query` and `raw_query` nested under server namespace
+
 
 ## 0.2.0 (2019-11-19)
 
 ### Features
 * new `raw_query` method. you have to write the graphql query
-  string by your self and also you get only the parsed json back. 
+  string by your self and also you get only the parsed json back.
 * query supports associations for the selected_fields attribute
 
 ## 0.1.0.beta1 (2019-10-06)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql_connector (0.2.0)
+    graphql_connector (1.0.0)
       httparty (~> 0.17)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # GraphqlConnector
 
 [![Gem
@@ -30,23 +31,26 @@ Or install it yourself as:
 You need to configure the `graphql_connector` first:
 ``` ruby
 GraphqlConnector.configure do |config|
-  config.host = ''
-  config.headers = {}
+  config.add_server(name: 'Foo', uri: 'http://foo.com/api/graphql', headers: {})
 end
+
+For each graphql server you wish to query use `add_server`.
 ```
 
 ### raw_query
 
 Then you can call your graphql_endpoint:
 ```ruby
-GraphqlConnector.raw_query(query_string)
+GraphqlConnector::<name>.raw_query(query_string)
 ```
+
+Note that `<name>` has to be replaced by any of the ones added via `add_mapping`
 
 ### query
 
 You can also use the more comfortable `query`:
 ```ruby
-GraphqlConnector.query(model, condition, selected_fields)
+GraphqlConnector::<name>.query(model, condition, selected_fields)
 ```
 
 | Variable        | DataType                | Example                                 |
@@ -58,7 +62,7 @@ GraphqlConnector.query(model, condition, selected_fields)
 > Caution:
 > You get an OpenStruct back. Currently only the first level attributes are
 > supported with OpenStruct, associated objects are still a normal array of
-> hashes. 
+> hashes.
 
 #### selected_fields
 

--- a/lib/graphql_connector.rb
+++ b/lib/graphql_connector.rb
@@ -3,6 +3,7 @@
 require 'graphql_connector/version'
 require 'graphql_connector/query_builder'
 require 'graphql_connector/configuration'
+require 'graphql_connector/http_client'
 require 'graphql_connector/custom_attribute_error'
 require 'httparty'
 

--- a/lib/graphql_connector.rb
+++ b/lib/graphql_connector.rb
@@ -4,6 +4,7 @@ require 'graphql_connector/version'
 require 'graphql_connector/query_builder'
 require 'graphql_connector/configuration'
 require 'graphql_connector/http_client'
+require 'graphql_connector/base_server_type'
 require 'graphql_connector/custom_attribute_error'
 require 'httparty'
 

--- a/lib/graphql_connector.rb
+++ b/lib/graphql_connector.rb
@@ -27,23 +27,4 @@ module GraphqlConnector
   def self.configure
     yield(configuration)
   end
-
-  def self.query(model, conditions, selected_fields)
-    query_string = QueryBuilder.new(model, conditions, selected_fields).create
-    parsed_body = raw_query(query_string)
-    OpenStruct.new(parsed_body['data'][model])
-  end
-
-  def self.raw_query(query_string)
-    response = HTTParty.post(GraphqlConnector.configuration.host,
-                             headers: GraphqlConnector.configuration.headers,
-                             body: { query: query_string })
-    parsed_body = JSON.parse(response.body)
-
-    if parsed_body.key? 'errors'
-      raise CustomAttributeError, parsed_body['errors']
-    end
-
-    parsed_body
-  end
 end

--- a/lib/graphql_connector/base_server_type.rb
+++ b/lib/graphql_connector/base_server_type.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module GraphqlConnector
+  class BaseServerTypeAlreadyExistsError < StandardError; end
+  # Class to wrap http_client calls under a specific namespaced class
+  class BaseServerType
+    class << self
+      def build(name, uri, headers)
+        verify_new_client_type_for!(name)
+        base_class = class_with(uri, headers)
+        base_object = GraphqlConnector.const_set(name, base_class)
+        inject_http_client(base_object)
+        inject_query_methods(base_object)
+
+        base_object
+      end
+
+      private
+
+      def verify_new_client_type_for!(name)
+        return unless GraphqlConnector.const_defined?(name)
+
+        raise BaseServerTypeAlreadyExistsError,
+              "The name: #{name} is already in use. Check your "\
+              'configuration!'
+      end
+
+      def class_with(uri, headers)
+        Class.new do
+          attr_accessor :uri, :headers
+          @uri = uri
+          @headers = headers
+        end
+      end
+
+      def inject_http_client(base_object)
+        base_object.instance_eval do
+          def http_client
+            @http_client ||= GraphqlConnector::HttpClient.new(@uri, @headers)
+          end
+        end
+      end
+
+      def inject_query_methods(base_object)
+        base_object.instance_eval do
+          def query(model, conditions, selected_fields)
+            http_client.query(model, conditions, selected_fields)
+          end
+
+          def raw_query(query_string)
+            http_client.raw_query(query_string)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql_connector/configuration.rb
+++ b/lib/graphql_connector/configuration.rb
@@ -3,11 +3,21 @@
 module GraphqlConnector
   # The configuration template file for the gem.
   class Configuration
-    attr_accessor :host, :headers
+    attr_reader :base_server_types
 
     def initialize
-      @host = nil
-      @headers = nil
+      @base_server_types = {}
+    end
+
+    def add_server(name:, uri:, headers:)
+      @base_server_types[name] = BaseServerType.build(name, uri, headers)
+    end
+
+    def reset!
+      @base_server_types.keys.each do |name|
+        GraphqlConnector.send :remove_const, name
+      end
+      @base_server_types = {}
     end
   end
 end

--- a/lib/graphql_connector/http_client.rb
+++ b/lib/graphql_connector/http_client.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module GraphqlConnector
+  # Wrapper class for HTTParty post query
+  class HttpClient
+    def initialize(uri, headers)
+      @uri = uri
+      @headers = headers
+    end
+
+    def query(model, conditions, selected_fields)
+      query_string = GraphqlConnector::QueryBuilder.new(model,
+                                                        conditions,
+                                                        selected_fields).create
+      parsed_body = raw_query(query_string)
+      result = parsed_body['data'][model]
+      return OpenStruct.new(result) unless result.is_a? Array
+
+      result.map { |entry| OpenStruct.new(entry) }
+    end
+
+    def raw_query(query_string)
+      response = HTTParty.post(@uri,
+                               headers: @headers,
+                               body: { query: query_string })
+      parsed_body = JSON.parse(response.body)
+      verify_response!(parsed_body)
+      parsed_body
+    end
+
+    private
+
+    def verify_response!(parsed_body)
+      return unless parsed_body.key? 'errors'
+
+      raise CustomAttributeError, parsed_body['errors']
+    end
+  end
+end

--- a/lib/graphql_connector/version.rb
+++ b/lib/graphql_connector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GraphqlConnector
-  VERSION = '0.2.0'
+  VERSION = '1.0.0'
 end

--- a/spec/graphql_connector/base_server_type_spec.rb
+++ b/spec/graphql_connector/base_server_type_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe GraphqlConnector::BaseServerType do
+  let(:type) { described_class }
+
+  describe '.build' do
+    subject(:build) { type.build(name, uri, headers) }
+    let(:name) { 'Foo' }
+    let(:uri) { 'http://bar.com/api/graphql' }
+    let(:headers) { { 'Authorization' => 'Bearer Test' } }
+
+    after do
+      GraphqlConnector.send :remove_const, name
+    end
+
+    it { is_expected.to eq(GraphqlConnector::Foo) }
+
+    it 'injects query method of http_client' do
+      build
+
+      expect(GraphqlConnector::Foo).to respond_to(:query)
+    end
+
+    it 'injects raw_query method of http_client' do
+      build
+
+      expect(GraphqlConnector::Foo).to respond_to(:raw_query)
+    end
+
+    context 'when using name again' do
+      let(:another_build) do
+        type.build(name, 'http://bar.com/graphql', {})
+      end
+
+      before do
+        build
+      end
+
+      it 'raises an ClientTypeAlreadyExistsError' do
+        expect { another_build }
+          .to raise_error(GraphqlConnector::BaseServerTypeAlreadyExistsError,
+                          /name/)
+      end
+    end
+  end
+end

--- a/spec/graphql_connector/configuration_spec.rb
+++ b/spec/graphql_connector/configuration_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe GraphqlConnector::Configuration do
+  let(:config) { described_class.new }
+
+  after do
+    config.reset!
+  end
+
+  describe '#add_server' do
+    subject(:add_server) do
+      config.add_server(name: name, uri: uri, headers: headers)
+    end
+    let(:name) { 'Foo' }
+    let(:uri) { 'http://foo.com' }
+    let(:headers) { {} }
+
+    it 'forwards params to BaseServerType build' do
+      expect(GraphqlConnector::BaseServerType)
+        .to receive(:build).with(name, uri, headers).and_call_original
+
+      add_server
+    end
+
+    it 'collects built BaseServerType' do
+      expect { add_server }
+        .to change { config.base_server_types.count }.from(0).to(1)
+    end
+  end
+
+  describe '#reset!' do
+    subject(:reset!) { config.reset! }
+
+    before do
+      config.add_server(name: 'Foo', uri: 'Foo', headers: {})
+    end
+
+    it 'empties base_server_types collection' do
+      expect { reset! }
+        .to change { config.base_server_types.count }.from(1).to(0)
+    end
+
+    it 'removes BaseServerType' do
+      expect { reset! }
+        .to change { GraphqlConnector.const_defined?('Foo') }
+        .from(true)
+        .to(false)
+    end
+  end
+end

--- a/spec/graphql_connector/http_client_spec.rb
+++ b/spec/graphql_connector/http_client_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe GraphqlConnector::HttpClient do
+  let(:client) { described_class.new(uri, headers) }
+  let(:uri) { 'http://foo.bar/graphql' }
+  let(:headers) { { 'Authorization' => 'Bearer Test' } }
+  let(:body) { { data: { cars: [{ name: 'Audi' }] } }.to_json }
+
+  before do
+    allow(HTTParty).to receive(:post)
+      .and_return(instance_double(HTTParty::Response, body: body))
+  end
+
+  describe '#query' do
+    subject(:query) { client.query(model, conditions, selected_fields) }
+    let(:model) { 'cars' }
+    let(:conditions) { { 'name' => 'Audi' } }
+    let(:selected_fields) { ['name'] }
+
+    it 'forwards params to query builder' do
+      expect(GraphqlConnector::QueryBuilder)
+        .to receive(:new).with(model, conditions, selected_fields)
+                         .and_call_original
+
+      query
+    end
+
+    it 'resolves query_string via raw_query' do
+      expect(client).to receive(:raw_query).with(String).and_call_original
+
+      query
+    end
+
+    it { is_expected.to contain_exactly(OpenStruct) }
+
+    it 'responds with correct value for name' do
+      expect(query.first.name).to eq('Audi')
+    end
+
+    context 'when response with a single element' do
+      let(:body) { { data: { cars: { name: 'Audi' } } }.to_json }
+
+      it { is_expected.to be_a(OpenStruct) }
+
+      it 'responds with correct value for name' do
+        expect(query.name).to eq('Audi')
+      end
+    end
+  end
+
+  describe 'raw_query' do
+    subject(:raw_query) { client.raw_query(query_string) }
+    let(:query_string) { 'query { cars(name: "audi") { name } }' }
+
+    it 'forwards params to HTTParty post' do
+      expect(HTTParty)
+        .to receive(:post)
+        .with(uri, headers: headers, body: { query: query_string })
+
+      raw_query
+    end
+
+    it { is_expected.to be_a(Hash) }
+
+    context 'when response contains errors' do
+      let(:body) { { errors: 'Cannot resolve for name' }.to_json }
+
+      it 'raises a CustomAttributeError' do
+        expect { raw_query }.to raise_error(CustomAttributeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updates gem to be able to query multiple different graphql servers

### Manual testing
* Start as many graphql servers as you want
* Configure Gem as described in README
* Perform `query` and `raw_query` against the graphql servers
* Expect to receive response as before