### PR TITLE
Bugfix conditions format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1 (2020-5-04)
+
+### BugFix
+* Omit invalid `()` for empty conditions in `query` method
+
 ## 1.1.0 (2020-4-19)
 
 ### Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql_connector (1.1.0)
+    graphql_connector (1.1.1)
       httparty (~> 0.17)
 
 GEM
@@ -62,4 +62,4 @@ DEPENDENCIES
   rubocop (~> 0.75)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/graphql_connector/query_builder.rb
+++ b/lib/graphql_connector/query_builder.rb
@@ -22,6 +22,8 @@ module GraphqlConnector
         array << "#{key}: #{value_as_parameter(value)}"
       end
 
+      return @model if conditions.empty?
+
       "#{@model}(#{conditions.join(', ')})"
     end
 

--- a/lib/graphql_connector/version.rb
+++ b/lib/graphql_connector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GraphqlConnector
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/graphql_connector/query_builder_spec.rb
+++ b/spec/graphql_connector/query_builder_spec.rb
@@ -12,8 +12,6 @@ module GraphqlConnector
 
     let(:expect_result) { 'query { product(id: 1) { id name } }' }
 
-    it 'returns a valid graphql query string' do
-      subject.equal? expect_result
-    end
+    it { is_expected.to eq(expect_result) }
   end
 end

--- a/spec/graphql_connector/query_builder_spec.rb
+++ b/spec/graphql_connector/query_builder_spec.rb
@@ -13,5 +13,12 @@ module GraphqlConnector
     let(:expect_result) { 'query { product(id: 1) { id name } }' }
 
     it { is_expected.to eq(expect_result) }
+
+    context 'with empty conditions' do
+      let(:conditions) { {} }
+      let(:expect_result) { 'query { product { id name } }' }
+
+      it { is_expected.to eq(expect_result) }
+    end
   end
 end


### PR DESCRIPTION
Omits `()` on empty conditions as this is mentioned to be an invalid format

### Manual testing
* Query a graphql server and omit the conditions on `query` method
* Expect to receive a response
* Doing the above step on `graphql_connector` version below `1.1.1` will raise an error