### PR TITLE
Relax httparty dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* relax httparty dependency
+
 ## 1.2.0 (2020-12-22)
 
 ### Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     graphql_connector (1.2.0)
-      httparty (~> 0.17)
+      httparty (~> 0.16)
 
 GEM
   remote: https://rubygems.org/
@@ -10,14 +10,14 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    httparty (0.18.0)
+    httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     jaro_winkler (1.5.4)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2021.0225)
     multi_xml (0.6.0)
     parallel (1.19.1)
     parser (2.7.1.1)

--- a/graphql_connector.gemspec
+++ b/graphql_connector.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'httparty', '~> 0.17'
+  spec.add_dependency 'httparty', '~> 0.16'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
This relaxes the minimum version of httparty from `0.17` to `0.16` to avoid conflicts in legacy applications.