### PR TITLE
add the option to use a connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0 (2021-06-02)
+
+* add the option to use a connector instead of init header for authorization
+  part of headers 
+
 ## 1.2.1 (2021-05-25)
 
 * relax httparty dependency(`~> 0.17` => `~> 0.16`)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql_connector (1.2.0)
+    graphql_connector (1.3.0)
       httparty (~> 0.16)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -30,9 +30,22 @@ Or install it yourself as:
 You need to configure the `graphql_connector` first:
 ``` ruby
 GraphqlConnector.configure do |config|
-  config.add_server(name: 'Foo', uri: 'http://foo.com/api/graphql', headers: {})
+  config.add_server(name: 'Foo', uri: 'http://foo.com/api/graphql', headers: {}, connector: {})
 end
 ```
+
+The connector is expecting that it contains a `base` connector instance and a
+`method` parameter as string, where it gets the token. Currently like this:
+```ruby
+{ base: TokenAgent.new, method: 'get_authorization_header' }
+```
+
+Your method should return a hash like this:
+```ruby
+{ 'Authorization' => 'Token HERE' }
+
+When you set a connector, it will override the setting in the headers for
+Authorization.
 
 For each graphql server you wish to query use `add_server`.
 

--- a/lib/graphql_connector/configuration.rb
+++ b/lib/graphql_connector/configuration.rb
@@ -9,8 +9,9 @@ module GraphqlConnector
       @base_server_types = {}
     end
 
-    def add_server(name:, uri:, headers:)
-      @base_server_types[name] = BaseServerType.build(name, uri, headers)
+    def add_server(name:, uri:, headers:, connector: {})
+      @base_server_types[name] =
+        BaseServerType.build(name, uri, headers, connector)
     end
 
     def reset!

--- a/lib/graphql_connector/version.rb
+++ b/lib/graphql_connector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GraphqlConnector
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/spec/graphql_connector/configuration_spec.rb
+++ b/spec/graphql_connector/configuration_spec.rb
@@ -16,10 +16,13 @@ describe GraphqlConnector::Configuration do
     let(:name) { 'Foo' }
     let(:uri) { 'http://foo.com' }
     let(:headers) { {} }
+    let(:connector) { {} }
 
     it 'forwards params to BaseServerType build' do
       expect(GraphqlConnector::BaseServerType)
-        .to receive(:build).with(name, uri, headers).and_call_original
+        .to receive(:build)
+        .with(name, uri, headers, connector)
+        .and_call_original
 
       add_server
     end


### PR DESCRIPTION
To prevent the connector from failing after a while when the token expire you get during the init process, you also have the option now to add a connector instance and a method to get a fresh token in every call.