### PR TITLE
Recursive OpenStructs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.4
+
 Layout/LineLength:
   Max: 100

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,4 +3,5 @@ Lint/DuplicateMethods:
     - lib/graphql_connector.rb
 Metrics/BlockLength:
   Exclude:
+    - "*.gemspec"
     - spec/graphql_connector/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 Write here
 
-### Braeking Changes
+### Breaking changes
 
-Write here
+* query results are now transformed to OpenStructs recursively, so nested attributes are no longer a hash but another OpenStruct
 
 ## 1.4.0 (2022-03-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Write here
 ### Breaking changes
 
 * query results are now transformed to OpenStructs recursively, so nested attributes are no longer a hash but another OpenStruct
+* Set minimum Ruby version to `2.4` or higher
 
 ## 1.4.0 (2022-03-17)
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,6 @@ GraphqlConnector::<name>.query('products', { id:  [1,2] } , ['id','name'], httpa
 | selected_fields          | Yes                           | Array of Strings/Hashes | ['id', 'name', productCategory: ['id']] |
 | httparty_adapter_options | No                            | Hash                    | { timeout: 3 }                          |
 
-:warning:
-> You get an OpenStruct back. Currently only the first level attributes are
-> supported with OpenStruct, associated objects are still a normal array of
-> hashes.
-
 See also [here](examples/query_examples.rb) for example usage
 
 #### selected_fields

--- a/graphql_connector.gemspec
+++ b/graphql_connector.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.4.0'
+
   spec.add_dependency 'httparty', '~> 0.16'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
This PR makes sure nested hashes are recursively transformed to an OpenStruct. Previously this was only done for the first level.

I had to increase the minimum Ruby version to 2.4 to be able to use `Hash#transform_values`. If that's not okay I'm happy to rewrite this without that method.